### PR TITLE
Enable event for some Miraheze domains

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -245,25 +245,25 @@
     redirect: 'miraheze.org'
     sslname: 'miraheze.tk'
     ca: 'LetsEncrypt'
-    disable_event: true
+    disable_event: false
   mirahezeml:
     url: 'miraheze.ml'
     redirect: 'miraheze.org'
     sslname: 'miraheze.ml'
     ca: 'LetsEncrypt'
-    disable_event: true
+    disable_event: false
   mirahezega:
     url: 'miraheze.ga'
     redirect: 'miraheze.org'
     sslname: 'miraheze.ga'
     ca: 'LetsEncrypt'
-    disable_event: true
+    disable_event: false
   mirahezegq:
     url: 'miraheze.gq'
     redirect: 'miraheze.org'
     sslname: 'miraheze.gq'
     ca: 'LetsEncrypt'
-    disable_event: true
+    disable_event: false
   dcwikiredirect:
     url: 'dc.miraheze.org'
     redirect: 'dc-multiverse.dcwikis.com'


### PR DESCRIPTION
We don't use wildcard certs for some Miraheze domains so we can enable the events.