### PR TITLE
Add arrowversewiki redirect to dcmultiversewiki

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -276,6 +276,12 @@
     sslname: 'wildcard.miraheze.org'
     ca: 'LetsEncrypt'
     disable_event: true
+  arrowversewikiredirect:
+    url: 'arrowverse.miraheze.org'
+    redirect: 'dc-multiverse.dcwikis.com'
+    sslname: 'wildcard.miraheze.org'
+    ca: 'LetsEncrypt'
+    disable_event: true
   dcmultiversewiki:
     url: 'dcmultiverse.miraheze.org'
     redirect: 'dc-multiverse.dcwikis.com'


### PR DESCRIPTION
After recently having arrowversewiki deleted I am now having it redirected to dcmultiversewiki.
I will most likely have this redirect removed and the subdomain opened up again in a couple of months.