### PR TITLE
Remove es.publictestwiki.com for deleted Spanish TestWiki

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -62,11 +62,6 @@
     url: 'wiki.teessidehackspace.org.uk'
     ca: 'LetsEncrypt'
     disable_event: false
-  prueba:
-    url: 'es.publictestwiki.com'
-    sslname: 'publictestwiki.com'
-    ca: 'LetsEncrypt'
-    disable_event: true
   nenawiki:
     url: 'nenawiki.org'
     ca: 'LetsEncrypt'

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -135,6 +135,12 @@
     sslname: 'publictestwiki.com'
     ca: 'LetsEncrypt'
     disable_event: true
+  espublictestwikicom:
+    url: 'es.publictestwiki.com'
+    redirect: 'publictestwiki.com'
+    sslname: 'publictestwiki.com'
+    ca: 'LetsEncrypt'
+    disable_event: true
   museummiddellandnl:
     url: 'museummiddelland.nl'
     redirect: 'www.museummiddelland.nl'


### PR DESCRIPTION
I'm not sure where my other commit is, but I'll check after I push this. Should be no changes to the private keys and certificates needed as it's all using the `publictestwiki.com` certificate

**Edit:**  Second commit added. I guess I needed to create the PR first, _then_ add my second commit? Anyway, this can probably wait till @Reception123 is up, unless @paladox wants to review it and advise me of thing missing.