### PR TITLE
disable events for ndg.nenawiki.org

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -187,7 +187,7 @@ ndgnenawiki:
   url: 'ndg.nenawiki.org'
   sslname: 'nenawiki.org'
   ca: 'LetsEncrypt'
-  disable_event: false
+  disable_event: true
 commonsgyaanipediacom:
   url: 'commons.gyaanipedia.com'
   ca: 'LetsEncrypt'


### PR DESCRIPTION
Not needed as done on nenawiki.org