### PR TITLE
Redirect test3 to betaheze

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -366,6 +366,13 @@ test2wiki:
   ca: 'Sectigo'
   hsts: 'strict'
   disable_event: true
+test3wiki:
+  url: 'test3.miraheze.org'
+  redirect: 'beta.betaheze.org'
+  sslname: 'wildcard.miraheze.org-2020-2'
+  ca: 'Sectigo'
+  hsts: 'strict'
+  disable_event: true
 betawiki:
   url: 'beta.miraheze.org'
   redirect: 'beta.betaheze.org'


### PR DESCRIPTION
This won't actually work until test3 is decommissioned, but I don't think it'll do any harm either.