### PR TITLE
Remove thesimswiki.com redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -48,12 +48,6 @@ wwwmarinebiodiversitymatrix:
   sslname: 'marinebiodiversitymatrix.org'
   ca: 'LetsEncrypt'
   disable_event: true
-thesimswikicom:
-  url: 'thesimswiki.com'
-  redirect: 'www.thesimswiki.com'
-  sslname: 'www.thesimswiki.com'
-  ca: 'LetsEncrypt'
-  disable_event: true
 wikithesimswikicom:
   url: 'wiki.thesimswiki.com'
   redirect: 'www.thesimswiki.com'


### PR DESCRIPTION
This redirect is causing alerts in icinga since its a root redirect without using a cname.