### PR TITLE
Add redirect for recaptimewiki's MH subdomain to its current custom domain

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -526,3 +526,10 @@ orain:
   sslname: 'orain.org'
   ca: 'LetsEncrypt'
   disable_event: true
+recaptimewiki:
+  url: 'recaptime.miraheze.org'
+  redirect: 'wiki.recaptime.eu.org'
+  sslname: 'wildcard.miraheze.org-2020-2'
+  ca: 'Sectigo'
+  hsts: 'strict'
+  disable_event: true

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -499,6 +499,13 @@ lgbtawiki:
   sslname: 'wildcard.miraheze.org-2020-2'
   ca: 'Sectigo'
   disable_event: true
+recaptimewiki:
+  url: 'recaptime.miraheze.org'
+  redirect: 'wiki.recaptime.eu.org'
+  sslname: 'wildcard.miraheze.org-2020-2'
+  ca: 'Sectigo'
+  hsts: 'strict'
+  disable_event: true
 
 # orain.org to miraheze.org wiki redirects
 allthetropesorain:
@@ -525,11 +532,4 @@ orain:
   redirect: 'meta.miraheze.org'
   sslname: 'orain.org'
   ca: 'LetsEncrypt'
-  disable_event: true
-recaptimewiki:
-  url: 'recaptime.miraheze.org'
-  redirect: 'wiki.recaptime.eu.org'
-  sslname: 'wildcard.miraheze.org-2020-2'
-  ca: 'Sectigo'
-  hsts: 'strict'
   disable_event: true


### PR DESCRIPTION
## About this change

This merge request contains an chnage in `redirects.yml` to redirect traffic from `recaptime.miraheze.org` to `wiki.recaptime.eu.org`, not necessarily for SEO reasons but to ensure people will not confused on the wiki URL, unless the `recaptime.eu.org` domain itself went dark or DNS stuff is broken.