### PR TITLE
Move miraheze.wiki to the top of redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4 +1,14 @@
 ---
+# miraheze.wiki redirects
+mirahezewiki:
+  url: 'miraheze.wiki'
+  redirect: 'meta.miraheze.org'
+  path_redirects:
+    ^/Fundraiser: 'meta.miraheze.org/wiki/Special:MyLanguage/Fundraiser'
+  sslname: 'miraheze.wiki'
+  ca: 'LetsEncrypt'
+  disable_event: true
+
 wwwallthetropes:
   url: 'www.allthetropes.org'
   redirect: 'allthetropes.org'
@@ -9,14 +19,6 @@ wwwpermanentfuturelab:
   url: 'www.permanentfuturelab.wiki'
   redirect: 'permanentfuturelab.wiki'
   sslname: 'permanentfuturelab.wiki'
-  ca: 'LetsEncrypt'
-  disable_event: true
-mirahezewiki:
-  url: 'miraheze.wiki'
-  redirect: 'meta.miraheze.org'
-  path_redirects:
-    ~* ^/Fundraiser: 'meta.miraheze.org/wiki/Special:MyLanguage/Fundraiser'
-  sslname: 'miraheze.wiki'
   ca: 'LetsEncrypt'
   disable_event: true
 mirahezecom:


### PR DESCRIPTION
* Should only be merged with miraheze/puppet#2641, at the same time.