### PR TITLE
Remove wiki.rtapp.tk from certs.yaml

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -1489,10 +1489,6 @@ robloxwiki:
   url: 'roblox-wiki.tk'
   ca: 'LetsEncrypt'
   disable_event: false
-wikirtapptk:
-  url: 'wiki.rtapp.tk'
-  ca: 'LetsEncrypt'
-  disable_event: false
 wikirecaptimetk:
   url: 'wiki.recaptime.tk'
   ca: 'LetsEncrypt'


### PR DESCRIPTION
We already defined it in redirects.yaml. we cannot have it defined in two places.