### PR TITLE
Remove wiki.recaptime.tk from certs.yaml

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -1489,10 +1489,6 @@ robloxwiki:
   url: 'roblox-wiki.tk'
   ca: 'LetsEncrypt'
   disable_event: false
-wikirecaptimetk:
-  url: 'wiki.recaptime.tk'
-  ca: 'LetsEncrypt'
-  disable_event: false
 wikiyahyabdxyz:
   url: 'wiki.yahyabd.xyz'
   ca: 'LetsEncrypt'


### PR DESCRIPTION
This is defined in redirects.yaml already and cannot be defined in two places.