### PR TITLE
Unset redirect for polandballwiki.com

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -438,12 +438,6 @@ squareenixwiki:
   sslname: 'wildcard.miraheze.org-2020-2'
   ca: 'Sectigo'
   disable_event: true
-polandballwiki:
-  url: 'polandball.miraheze.org'
-  redirect: 'www.polandballwiki.com'
-  sslname: 'wildcard.miraheze.org-2020-2'
-  ca: 'Sectigo'
-  disable_event: true
 mariowiki:
   url: 'mario.miraheze.org'
   redirect: 'mariopedia.org'


### PR DESCRIPTION
Registrar is having issues with renewals so the domain is in an odd state so unsetting the custom domain for a bit per request