### PR TITLE
Redirect static-new.miraheze.org to static.miraheze.org

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -47,6 +47,13 @@ piwik:
   ca: 'Sectigo'
   hsts: 'strict'
   disable_event: true
+static:
+  url: 'static-new.miraheze.org'
+  redirect: 'static.miraheze.org'
+  sslname: 'wildcard.miraheze.org-2020-2'
+  ca: 'Sectigo'
+  hsts: 'strict'
+  disable_event: true
 wikithesimswikicom:
   url: 'wiki.thesimswiki.com'
   redirect: 'www.thesimswiki.com'


### PR DESCRIPTION
Temporary until we cleanup instances in the databases (like GlobalNewFiles and ManageWiki settings)