### PR TITLE
Remove famepedia.org

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -552,10 +552,6 @@ celestewiki:
   url: 'celeste.ink'
   ca: 'LetsEncrypt'
   disable_event: false
-datafamepediaorg:
-  url: 'data.famepedia.org'
-  ca: 'LetsEncrypt'
-  disable_event: false
 gpct777cf:
   url: 'gp.ct777.cf'
   ca: 'LetsEncrypt'


### PR DESCRIPTION
Domain no longer registered and no longer points at us.