### PR TITLE
Fix projectpatternscom name in redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -183,7 +183,7 @@ wwwambientguitarorg:
   sslname: 'ambientguitar.org'
   ca: 'LetsEncrypt'
   disable_event: false
-projectpatternscom:
+wwwprojectpatternscom:
   url: 'www.project-patterns.com'
   redirect: 'project-patterns.com'
   sslname: 'project-patterns.com'


### PR DESCRIPTION
It's conflicting with the name in certs.yaml.