### PR TITLE
Allow events for pyramidgames.wiki

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -212,7 +212,7 @@ looneypyramidgameswiki:
   redirect: 'looneypyramids.wiki'
   sslname: 'pyramidgames.wiki'
   ca: 'LetsEncrypt'
-  disable_event: true
+  disable_event: false
 wikifediversekr:
   url: 'wiki.fediverse.kr'
   redirect: 'wiki.mastodon.kr'


### PR DESCRIPTION
We keep it disable for www.pyramidgames.wiki as we don't want it to trigger twice.