### PR TITLE
T12203: Remove miraheze.com -> meta.miraheze.org redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -45,7 +45,6 @@ wwwpermanentfuturelab:
   disable_event: true
 mirahezecom:
   url: 'miraheze.com'
-  redirect: 'meta.miraheze.org'
   sslname: 'miraheze.com'
   ca: 'LetsEncrypt'
   disable_event: false


### PR DESCRIPTION
This is a temp solution to unbreak cert renews on that domain. This can be reverted once the cert has been renewed

https://issue-tracker.miraheze.org/T12203