### PR TITLE
T12430: Redirect strinova.miraheze.org to strinova.org

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -519,6 +519,13 @@ pizzatowerwiki:
   ca: 'Sectigo'
   hsts: 'strict'
   disable_event: true
+strinovawiki:
+  url: 'strinova.miraheze.org'
+  redirect: 'strinova.org'
+  sslname: 'wildcard.miraheze.org-2020-2'
+  ca: 'Sectigo'
+  hsts: 'strict'
+  disable_event: true
 rippaversewiki:
   url: 'rippaverse.wikitide.org'
   redirect: 'rippaversewiki.com'


### PR DESCRIPTION
Resolve T12430 by imitating other `miraheze.org` to custom domain redirects. The domain `strinova.org` is managed by Cloudflare, so hopefully it doesn't make a difference in redirect configurations. 