### PR TITLE
Serve the miraheze.org wildcard on wiki.themanaworld.org

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -2075,7 +2075,8 @@ wkmrliaomedia:
   disable_event: false
 wikithemanaworldorg:
   url: 'wiki.themanaworld.org'
-  ca: 'LetsEncrypt'
+  ca: 'Sectigo'
+  sslname: 'wildcard.miraheze.org-2020-2'
   disable_event: false
 wikisecondrenaissancenet:
   url: 'wiki.secondrenaissance.net'


### PR DESCRIPTION
wiki.themanaworld.org is a domain routed via Cloudflare.

This is a test for whether or not Cloudflare will like mw* serving this certificate on a custom domain.