### PR TITLE
T13039: acuralegendwiki.org: Redirect /index.php to /wiki

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -2850,6 +2850,9 @@ acuralegendwikiorg:
   url: 'acuralegendwiki.org'
   ca: 'LetsEncrypt'
   disable_event: false
+  rewrites:
+    - '^/index\\.php/?$': '/wiki/ redirect'
+    - '^/index\\.php/(.+)$': '/wiki/$1 redirect'
 gielinorgameswiki:
   url: 'gielinorgames.wiki'
   ca: 'LetsEncrypt'


### PR DESCRIPTION
Depends on https://github.com/miraheze/puppet/pull/4135

Fixes T13039