### PR TITLE
T13707: Redirect www.kingdomway.wiki -> kingdomway.wiki

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -206,6 +206,11 @@ avidwikiredirect:
   redirect: 'www.avid.wiki'
   ca: 'Cloudflare'
   sslname: 'miraheze-origin-cert'
+wwwkingdomwaywiki:
+  url: 'www.kingdomway.wiki'
+  redirect: 'kingdomway.wiki'
+  ca: 'Cloudflare'
+  sslname: 'miraheze-origin-cert'
 # *.miraheze.org/*.wikitide.org to wiki custom domains redirects
 allthetropeswiki:
   url: 'allthetropes.miraheze.org'


### PR DESCRIPTION
Not explicitly stated, but I'm guessing that's what they want since a CNAME for www.kingdomway.wiki is also set up