### PR TITLE
T13844: Remove alternatewiki.tombricks.com from certs.yaml

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -924,10 +924,6 @@ wikiluemirxyz:
   url: 'wiki.luemir.xyz'
   ca: 'Cloudflare'
   sslname: miraheze-origin-cert
-alternatewikitombrickscom:
-  url: 'alternatewiki.tombricks.com'
-  ca: 'Cloudflare'
-  sslname: miraheze-origin-cert
 wikistarshipsailingnet:
   url: 'wiki.starshipsailing.net'
   ca: 'Cloudflare'


### PR DESCRIPTION
Partially resolves [T13844](https://issue-tracker.miraheze.org/T13884).
Possible follow-up needed on the Cloudflare side.