### PR TITLE
T13926: Redirect backroomszh.miraheze.org to wiki.backroomszh.org

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -449,7 +449,7 @@ bunkshelfwiki:
   hsts: 'strict'
 backroomszhwiki:
   url: 'backroomszh.miraheze.org'
-  redirect: 'www.backroomszh.wiki'
+  redirect: 'wiki.backroomszh.org'
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'


### PR DESCRIPTION
Resolves [T13926](https://issue-tracker.miraheze.org/T13926).