### PR TITLE
T13933: Redirect nullscape.miraheze.org to nullscape.wiki

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -489,6 +489,12 @@ legitimoosewiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
+nullscapewiki:
+  url: 'nullscape.miraheze.org'
+  redirect: 'nullscape.wiki'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
 # *.miraheze.org to *.miraheze.org wiki redirects
 wwwredirect:
   url: 'www.miraheze.org'


### PR DESCRIPTION
Resolves [T13933](https://issue-tracker.miraheze.org/T13933).