### PR TITLE
T13998: Remove 321nailswiki cert and redirect

### DIFF
--- a/certs.yaml
+++ b/certs.yaml
@@ -648,10 +648,6 @@ wikiauraxisco:
   url: 'wiki.auraxis.co'
   ca: 'Cloudflare'
   sslname: miraheze-origin-cert
-321nailscrpteam:
-  url: '321nails.crpteam.club'
-  ca: 'Cloudflare'
-  sslname: miraheze-origin-cert
 wikipuucraftnet:
   url: 'wiki.puucraft.net'
   ca: 'Cloudflare'

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -268,12 +268,6 @@ pandorastale:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
-321nailswiki:
-  url: '321nailswiki.miraheze.org'
-  redirect: '321nails.crpteam.club'
-  sslname: 'miraheze-origin-cert'
-  ca: 'Cloudflare'
-  hsts: 'strict'
 luxuryelevatorwiki:
   url: 'luxuryelevator.miraheze.org'
   redirect: 'wiki.theluxuryelevator.com'


### PR DESCRIPTION
Resolves [T13998](https://issue-tracker.miraheze.org/T13998).