### PR TITLE
Redirect dpl4.wikitide.org to dpl3.wikitide.org

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -29,6 +29,11 @@ wwwwikitideredirect:
   redirect: 'miraheze.org'
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
+dpl3wiki:
+  url: 'dpl4.wikitide.org'
+  redirect: 'dpl3.wikitide.org'
+  sslname: 'wikitide.org'
+  ca: 'LetsEncrypt'
 wwwallthetropes:
   url: 'www.allthetropes.org'
   redirect: 'allthetropes.org'


### PR DESCRIPTION
This will be reversed when the wiki has been renamed but for now just redirect dpl4.wikitide.org to dpl3.wikitide.org.