### PR TITLE
T14026: Redirect modernbeta.miraheze.org to wiki.modernbeta.org

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -530,6 +530,12 @@ r6danceswiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
+modernbetawiki:
+  url: 'modernbeta.miraheze.org'
+  redirect: 'wiki.modernbeta.org'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
 # *.miraheze.org to *.miraheze.org wiki redirects
 wwwredirect:
   url: 'www.miraheze.org'


### PR DESCRIPTION
Resolves [T14026](https://issue-tracker.miraheze.org/T14026).