### PR TITLE
T14161: Remove redirect from wiki to its custom domain

### DIFF
--- a/cloudflare_domains
+++ b/cloudflare_domains
@@ -302,7 +302,6 @@ rosettacode.org
 rothwell-leeds.co.uk
 ru.countryhumans.polandball.wiki
 santuy.nisaka.net
-sarasa.iml.menhera.org
 sarovia.graalmilitary.com
 sdiy.info
 serin.wiki

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -426,12 +426,6 @@ dreamsciencewiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
-sarasawiki:
-  url: 'sarasa.miraheze.org'
-  redirect: 'sarasa.iml.menhera.org'
-  sslname: 'miraheze-origin-cert'
-  ca: 'Cloudflare'
-  hsts: 'strict'
 everythingupgradetreewiki:
   url: 'everythingupgradetree.miraheze.org'
   redirect: 'eutwiki.com'

--- a/wikidiscover_output.yaml
+++ b/wikidiscover_output.yaml
@@ -466,7 +466,6 @@ sagan4wiki: https://meta.sagan4.org
 samskritavyakaranamwiki: https://worldsanskrit.net
 sanarsivwiki: https://tr.sanarsiv.org
 sanarxivwiki: https://az.sanarsiv.org
-sarasawiki: https://sarasa.iml.menhera.org
 saroviawikiwiki: https://sarovia.graalmilitary.com
 schmeckanerwiki: https://wiki.schmeckaner.org
 sdcnbackroomswiki: https://www.backroomssd.top


### PR DESCRIPTION
The community decided to abolish the custom domain (`sarasa.iml.menhera.org`) for `sarasawiki`, but the 301 redirect is still pointing there. Since the domain no longer exists, the redirect makes it impossible to access Sarasawiki for viewing or editing.  
This change removes all entries that appear related to the custom domain setup for `sarasawiki`.  
I'm not entirely sure if the file changes are correct, if editing `redirects.yaml` alone is sufficient, please adjust accordingly.  