### PR TITLE
Add redirects for recaptimesquadwiki (alongside old miraheze.org subdomains

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -795,7 +795,7 @@ recaptimewiki:
   ca: 'Cloudflare'
   hsts: 'strict'
 communitycentralbympteamwiki:
-  url: communitycentralbympteam.miraheze.org
+  url: 'communitycentralbympteam.miraheze.org'
   redirect: 'hq.recaptime.dev'
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -782,6 +782,24 @@ dstrwikiwiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
+recaptimesquadwiki:
+  url: 'recaptimesquad.miraheze.org'
+  redirect: 'hq.recaptime.dev'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
+recaptimewiki:
+  url: 'recaptime.miraheze.org'
+  redirect: 'hq.recaptime.dev'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
+communitycentralbympteamwiki:
+  url: communitycentralbympteam.miraheze.org
+  redirect: 'hq.recaptime.dev'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
 # *.miraheze.org to *.miraheze.org wiki redirects
 wwwredirect:
   url: 'www.miraheze.org'


### PR DESCRIPTION
This patch resolves https://issue-tracker.miraheze.org/T14988 by setting up a redirect for `recaptimesquad.miraheze.org` to its custom domain (`hq.recaptime.dev`) alongside its former subdomains (`recaptime` and `communitycentralbympteam`).