### PR TITLE
Add redirect: loveanddeepspace.miraheze.org → lads.wiki

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -793,11 +793,6 @@ loveanddeepspacewiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
-wwwladswiki:
-  url: 'www.lads.wiki'
-  redirect: 'lads.wiki'
-  ca: 'Cloudflare'
-  sslname: 'miraheze-origin-cert'
 quantumsciencewiki:
   url: 'quantumscience.miraheze.org'
   redirect: 'wiki.quantum-science.net'

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -787,6 +787,17 @@ kaiserreichwiki:
   sslname: 'miraheze-origin-cert'
   ca: 'Cloudflare'
   hsts: 'strict'
+loveanddeepspacewiki:
+  url: 'loveanddeepspace.miraheze.org'
+  redirect: 'lads.wiki'
+  sslname: 'miraheze-origin-cert'
+  ca: 'Cloudflare'
+  hsts: 'strict'
+wwwladswiki:
+  url: 'www.lads.wiki'
+  redirect: 'lads.wiki'
+  ca: 'Cloudflare'
+  sslname: 'miraheze-origin-cert'
 quantumsciencewiki:
   url: 'quantumscience.miraheze.org'
   redirect: 'wiki.quantum-science.net'


### PR DESCRIPTION
Add 301 redirect from old Miraheze subdomain loveanddeepspace.miraheze.org to custom domain lads.wiki, plus www.lads.wiki to lads.wiki redirect.